### PR TITLE
Correctly remove all existing bookmarks

### DIFF
--- a/bookmarks_safari_to_chrome.applescript
+++ b/bookmarks_safari_to_chrome.applescript
@@ -1,16 +1,29 @@
 tell application "System Events" to tell process "Google Chrome"
 	tell application "Google Chrome"
-		set bookmarks to {}
+		set folderNames to {}
 		repeat with i from 1 to count of bookmark folders of bookmark folder "Bookmarks Bar"
-			set bookmark to item i of bookmark folders of bookmark folder "Bookmarks Bar"
-			set bookmarkName to title of bookmark
-			copy bookmarkName to end of bookmarks
+			set folderItem to item i of bookmark folders of bookmark folder "Bookmarks Bar"
+			set folderName to title of folderItem
+			copy folderName to end of folderNames
 		end repeat
 		
-		repeat with i from 1 to count of bookmarks
-			set bookmark to item i of bookmarks
-			set folderToDelete to bookmark folder bookmark of bookmark folder "Bookmarks Bar"
-			delete folderToDelete
+		repeat with i from 1 to count of folderNames
+			set folderName to item i of folderNames
+			set folderItem to bookmark folder folderName of bookmark folder "Bookmarks Bar"
+			delete folderItem
+		end repeat
+		
+		set bookmarkNames to {}
+		repeat with i from 1 to count of bookmark items of bookmark folder "Bookmarks Bar"
+			set bookmarkItem to item i of bookmark items of bookmark folder "Bookmarks Bar"
+			set bookmarkName to title of bookmarkItem
+			copy bookmarkName to end of bookmarkNames
+		end repeat
+		
+		repeat with i from 1 to count of bookmarkNames
+			set bookmark to item i of bookmarkNames
+			set bookmarkItem to bookmark item bookmark of bookmark folder "Bookmarks Bar"
+			delete bookmarkItem
 		end repeat
 	end tell
 	


### PR DESCRIPTION
Correctly remove all existing bookmarks so that the imported bookmarks aren't added to the "Other bookmarks" folder at the end of the bookmarks bar.